### PR TITLE
Enables the 'Edit' menu in OSX Menubar, enable Cut/Copy/Paste

### DIFF
--- a/desktop-app/js/tinder++.js
+++ b/desktop-app/js/tinder++.js
@@ -9,7 +9,7 @@
   if (process.platform === 'darwin') {
     var nativeMenuBar = new gui.Menu({ type: 'menubar' });
     nativeMenuBar.createMacBuiltin('Tinder⁺⁺', {
-      hideEdit: true
+      hideEdit: false
     });
     win.menu = nativeMenuBar;
   }


### PR DESCRIPTION
This makes OS standard commands for text editing (cut, copy, paste, emacs-style
movement) work in text boxes in the app.

Fixes #29