### PR TITLE
Improved layout, pending messages, scroll to bottom

### DIFF
--- a/desktop-app/css/app.css
+++ b/desktop-app/css/app.css
@@ -1,3 +1,4 @@
+/* General styles */
 * {
     font-family: 'Merriweather', serif;
     -webkit-touch-callout: none;
@@ -7,12 +8,6 @@
 
 h1, h2, h3, h4, h5 {
     font-family: 'Raleway', sans-serif;
-}
-
-html, body {
-    max-width: 100%;
-    max-height: 100%;
-    overflow-x: hidden;
 }
 
 a {
@@ -39,6 +34,35 @@ a {
     clear: both;
 }
 
+/* General layout */
+html, body, body > div.ng-scope {
+    max-width: 100%;
+    max-height: 100%;
+    overflow-x: hidden;
+    overflow-y: hidden;
+    height: 100%;
+}
+
+.y-scroll {
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: 100%;
+}
+
+.columns {
+    display: flex;
+    overflow: hidden;
+    height: 100%;
+}
+
+.columns > div {
+    flex: 1;
+    overflow-x: hidden;
+    overflow-y: auto;
+    height: 100%;
+}
+
+/* Specific */
 .title-bar {
     width: 100%;
     height: 25px;
@@ -271,24 +295,32 @@ a {
     content: ')';
 }
 
+/* Messages screen */
+#messages {
+    display: flex;
+    height: 100%;
+}
+
 /* Chat */
 #match-list {
     width: 185px;
-    height: 100%;
-    position: fixed;
-    overflow-x: hidden;
-    overflow-y: scroll;
-    float: left;
+    border-right: 1px solid #ddd;
+    flex: initial;
+}
+#match-list.more-info {
+    width: 215px;
 }
 #back-arrow {
     margin: 3px calc(75px - 1em);
 }
 .match {
+    display: block;
     border-bottom: 1px solid #ddd;
-    padding: 0;
+    padding: 3px 0;
     margin: 0 5px;
     height: 42px; /* Thumbnail size: 84px */
     cursor: pointer;
+    color: inherit;
 }
 .match .thumbnail {
     display: inline-block;
@@ -305,10 +337,14 @@ a {
     font-weight: bold;
     overflow: hidden;
     text-overflow: ellipsis;
+    padding-left: .5em;
 }
 .match.more-info {
-    height: 64px;
     padding: 5px;
+}
+
+.match.more-info .name {
+    line-height: 22px;
 }
 
 .match .info {
@@ -323,15 +359,30 @@ a {
 
 /* from http://codepen.io/samuelkraft/pen/Farhl */
 #conversation {
-    width: calc(100% - 205px);
-    height: 100%;
-    float: right;
     font-family: "Helvetica Neue", sans-serif;
     font-size: 1.1em;
     line-height: 20px;
     font-weight: normal;
-    padding: 3px 14px;
+    display: flex;
+    flex-direction: column;
 }
+#conversation div {
+    flex: 1;
+}
+#conversation h2 {
+    padding: 0 14px 14px 11px;
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 0;
+}
+#conversation .messages-list {
+    overflow-y: scroll;
+  overflow-x: hidden;
+  padding: 14px;
+}
+#conversation .messages-list-empty {
+  padding: 14px;
+}
+
 #conversation div.from-me,
 #conversation div.from-them {
     max-width: 51%;
@@ -339,14 +390,15 @@ a {
     margin-bottom: 10px;
 }
 #conversation textarea {
-    margin-top: 5px;
     font-size: 1em;
     outline: none;
-    border: 1px solid #ccc;
-    border-radius: 9px;
+    border: solid #ccc;
+    border-width: 1px 0 0 0;
+    border-radius: 0;
     width: 100%;
     padding: 10px;
     box-sizing: border-box;
+      margin: 0;
 }
 
 .clear {

--- a/desktop-app/index.html
+++ b/desktop-app/index.html
@@ -57,6 +57,7 @@
 <div ng-view></div>
 
 <script type="text/ng-template" id="swipe.html">
+<div class="y-scroll">
   <div class="user">
     <div class="left" ng-show="apiQueue.length > 0">
       <a href="" ng-click="undo()">
@@ -120,6 +121,7 @@
       </div>
     </div>
   </div>
+</div>
 </script>
 
 <script type="text/ng-template" id="login.html">
@@ -132,35 +134,48 @@
 </script>
 
 <script type="text/ng-template" id="messages.html">
-  <div id="match-list">
+<div id="messages" class="columns">
+  <div id="match-list" ng-class="showExtra && 'more-info'">
     <a ng-href="#/swipe"><i id="back-arrow" class="fa fa-arrow-left fa-2x"></i></a>
     <div ng-repeat="match in conversations | orderObjectBy:'lastActive':true track by match.matchId"
          ng-click="open(match.matchId)" 
          ng-class="showExtra && match.infoUpdateTime && 'more-info'"
          class="match">
       <img ng-src="{{match.thumbnail || 'img/anonymous.png'}}" class="thumbnail"/>
-      <p class="name">{{match.name || 'Unknown'}}</p>
-      <p class="info" ng-show="showExtra && match.infoUpdateTime">
-        <i class="fa fa-location-arrow"></i> {{match.userDistanceMi}} | 
-        <i class="fa fa-bolt"></i> <span short-time-ago="{{match.userPingTime}}"></span> | 
-        <i class="fa fa-comments" ng-class="lastMessageClass(match)"></i> <span short-time-ago="{{match.lastActive}}"></span>
-      </p>
+      <div>
+        <p class="name">{{match.name || 'Unknown'}}</p>
+        <p class="info" ng-show="showExtra && match.infoUpdateTime">
+          <i class="fa fa-location-arrow"></i> {{match.userDistanceMi}} |
+          <i class="fa fa-bolt"></i> <span short-time-ago="{{match.userPingTime}}"></span> |
+          <i class="fa fa-comments" ng-class="lastMessageClass(match)"></i> <span short-time-ago="{{match.lastActive}}"></span>
+        </p>
+      </div>
     </div>
   </div>
   <div id="conversation" ng-show="conversation">
     <h2 class="message-header">
       Chat with <a ng-href="#/profile/{{conversation.userId}}">{{conversation.name}}</a>
     </h2>
-    <div ng-show="conversation.messages.length == 0">
+    <div ng-show="conversation.messages.length == 0" class="messages-list-empty">
       No messages yet. Write something!
     </div>
-    <div ng-repeat-start="message in conversation.messages track by $index"
-         class="{{message.fromMe ? 'from-me' : 'from-them'}}">
-      <p ng-if="message.text">{{message.text}}</p>
+    <div class="messages-list">
+      <!-- normal messages -->
+      <div ng-repeat-start="message in conversation.messages track by $index"
+          class="{{message.fromMe ? 'from-me' : 'from-them'}}">
+        <p ng-if="message.text">{{message.text}}</p>
+      </div>
+      <div ng-repeat-end class="clear"></div>
+      <!-- pending messages -->
+      <div ng-repeat-start="message in conversation.pending track by $index"
+          class="from-me">
+        <p>{{message}}</p>
+      </div>
+      <div ng-repeat-end class="clear"></div>
     </div>
-    <div ng-repeat-end class="clear"></div>
     <textarea ng-keypress="keypress($event)" ng-model="message" rows="4" placeholder="Insert something witty here...">
   </div>
+</div>
 </script>
 
 <script type="text/ng-template" id="profile.html">

--- a/desktop-app/index.html
+++ b/desktop-app/index.html
@@ -165,13 +165,13 @@
           class="{{message.fromMe ? 'from-me' : 'from-them'}}">
         <p ng-if="message.text">{{message.text}}</p>
       </div>
-      <div ng-repeat-end class="clear"></div>
+      <div ng-repeat-end class="clear" scroll-to-last></div>
       <!-- pending messages -->
       <div ng-repeat-start="message in conversation.pending track by $index"
           class="from-me">
         <p>{{message}}</p>
       </div>
-      <div ng-repeat-end class="clear"></div>
+      <div ng-repeat-end class="clear" scroll-to-last></div>
     </div>
     <textarea ng-keypress="keypress($event)" ng-model="message" rows="4" placeholder="Insert something witty here...">
   </div>

--- a/desktop-app/js/tinder++.controls.js
+++ b/desktop-app/js/tinder++.controls.js
@@ -117,6 +117,7 @@
         name: (match.person ? match.person.name : null),
         thumbnail: (match.person ? match.person.photos[0].processedFiles[3].url : null),
         messages: [],
+        pending: [],
         lastActive: match.created_date
       };
     }
@@ -128,6 +129,11 @@
         text: message.message,
         fromMe: (message.from == localStorage.userId)
       })
+      // Remove possibly pending messages
+      var pending = API.conversations[message.match_id].pending;
+      if(Array.isArray(pending) && pending.indexOf(message.message) >= 0) {
+        pending.splice(pending.indexOf(message.message), 1);
+      }
     }
 
     function addMatchToInfoQueue(matchId) {

--- a/desktop-app/js/tinder++.messages.js
+++ b/desktop-app/js/tinder++.messages.js
@@ -32,9 +32,13 @@
         event.preventDefault();
         if ($scope.message.length > 0) {
           API.sendMessage($scope.conversation.matchId, $scope.message);
-          $scope.message = '';
           ga_storage._trackEvent('Messages', 'sent message');
           window._rg.record('messages', 'sent message', { origin: 'tinderplusplus' });
+          // Show pending message
+          $scope.conversation.pending = $scope.conversation.pending || [];
+          $scope.conversation.pending.push($scope.message);
+          // Reset
+          $scope.message = '';
         }
       }
     };

--- a/desktop-app/js/tinder++.messages.js
+++ b/desktop-app/js/tinder++.messages.js
@@ -95,4 +95,16 @@
       return days + 'd';
     }
   });
+
+  // Scroll to bottom in conversations
+  module.directive('scrollToLast', function() {
+    return function(scope, element, attrs) {
+      if(scope.$last) {
+        console.log("Scrolling", scope);
+        setTimeout(function(){
+          angular.element(element)[0].scrollIntoView();
+        });
+      }
+    };
+  });
 })();


### PR DESCRIPTION
This pull request offers several improvements:

- The old fixed layout causes some issues with overlapping elements, which is now resolved by using css3's flex layout. No need for any calc() anymore, just use either flex: 1 or define a fixed width. See attached images for net result.
- Pending messages. When sending a message it would just disappear until Tinder's API acks it. This was so slow I decided to add a pending message queue. So now you can see messages that are pending immediately. Needs some timer icon still, to show the difference.
- Scroll to bottom once you open a conversation. Implemented using Angular directives, so that new messages also cause scroll to bottom. Would still like something like a notification symbol in the matches list, but that remains to be done.

old | new
---- | ----
![oldlayout](https://cloud.githubusercontent.com/assets/791189/12549588/898e11c8-c35e-11e5-80b8-be47b247dd9a.png) | ![newlayout](https://cloud.githubusercontent.com/assets/791189/12549587/8971e5ac-c35e-11e5-95ea-fee2b5732bec.png)